### PR TITLE
🤯 修复 html2canvas 文字偏移问题

### DIFF
--- a/src/assets/style/index.css
+++ b/src/assets/style/index.css
@@ -8,9 +8,6 @@
 html,body {
   font-size: 16px;
 }
-body {
-  /* background: var(--main-bg-color); */
-}
 
 @font-face{
   font-family: Alipuhui;
@@ -23,4 +20,9 @@ body {
 
 .btn {
   @apply inline-block px-5 py-2 rounded-lg tracking-widest cursor-pointer;
+}
+
+/* tailwind base 中引起文字偏移的属性 */
+img {
+  display: unset;
 }


### PR DESCRIPTION
## 问题
因为 `@tailwind base` 中
```css
img {
  display: block;
}
```
导致文字向下偏移，所以改为 unset 解决

## 效果图
![1651936339540](https://user-images.githubusercontent.com/37147926/167260747-f26fe9c1-c854-42c1-a1bb-e64c75a66b66.png)
